### PR TITLE
Implement threaded scanning option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+.PHONY: lint test run
+
+lint:
+	ruff check .
+	mypy ioc_inspector_core main.py
+
+test:
+	pytest -q
+
+run:
+	python main.py $(ARGS)

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 - Dynamic API key loading for test reliability
 - Coverage-gated CI with **>80%** unit test coverage
 - Final README polish ✨
+- Concurrent directory scanning with `--threads`
 
 ---
 
@@ -42,8 +43,9 @@
 | **IOC Extraction**  | URLs • Domains • IPs • Base64 blobs • Hidden links                                                 |
 | **Threat Enrichment** | VirusTotal • AbuseIPDB                                                                      |
 | **Scoring Engine**  | Heuristic weights + rule modifiers (configurable)                                                  |
-| **Reporting**       | Markdown & JSON (CSV optional)                                                                     |
-| **Automation**      | Dir-recursive scan • Quiet / Verbose switches • GitHub Actions workflow                            |
+| **Reporting**       | Markdown, JSON, CSV, JSONL, HTML
+                                          |
+| **Automation**      | Dir-recursive scan • `--threads` for concurrency • Quiet/Verbose switches • GitHub Actions workflow |
 
 ---
 
@@ -125,7 +127,7 @@ ioc-inspector/
 | Category | Package | Why it’s needed |
 |----------|---------|-----------------|
 | Core     | `oletools`, `pdfminer.six`, `PyMuPDF`, `requests`, `python-dotenv`, `tldextract` | Parsing, enrichment, API config |
-| Reporting| *(builtin)* | Markdown/JSON rendering |
+| Reporting| *(builtin)* | Markdown/JSON/CSV/JSONL/HTML rendering |
 | Optional | `tabulate`, `rich`, `jinja2` | Pretty console output, HTML reports |
 
 ---
@@ -198,12 +200,12 @@ This outlines the path for taking IOC Inspector from a solid prototype (v0.1.0) 
 Focus: Hardening the product & improving feedback loop
 
 ### Technical Improvements
-- [ ] JSON schema validation for report output
+- [x] JSON schema validation for report output
 - [ ] Improve error messaging with file context (e.g., filetype, parser used)
 - [ ] Separate reporting logic from CLI to enable more formats
 
 ### Developer Experience
-- [ ] Add `make test`, `make lint`, `make run` shortcuts
+- [x] Add `make test`, `make lint`, `make run` shortcuts
 - [ ] Add GitHub Discussions or feedback template
 - [ ] Incorporate feedback from test users
 
@@ -212,9 +214,9 @@ Focus: Hardening the product & improving feedback loop
 ## ✨ Phase 3: Export & Integrations (`v0.3.x`)
 Focus: SIEM-friendliness & analyst use
 
-- [ ] CSV export for Splunk or Excel
-- [ ] JSONL support for batch pipelines
-- [ ] HTML export with embedded styles
+- [x] CSV export for Splunk or Excel
+- [x] JSONL support for batch pipelines
+- [x] HTML export with embedded styles
 - [ ] Normalize field naming for ingestion (e.g. `ioc.type`, `ioc.source`)
 - [ ] (Optional) Tag known MITRE ATT&CK techniques from enriched IOCs
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,5 @@
 pytest==8.2.0
 pytest-cov==5.0.0
 ruff==0.4.5
+types-requests==2.32.4.20250611
+jsonschema==4.22.0

--- a/ioc_inspector_core/abuseipdb_check.py
+++ b/ioc_inspector_core/abuseipdb_check.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import os
 import time
+from functools import lru_cache
 from typing import Any, Dict, List, Union
 
 import requests
@@ -34,6 +35,7 @@ _MAX_AGE = 90
 _RATE_PAUSE = 1.2
 
 
+@lru_cache(maxsize=128)
 def _fetch_abuse_data(ip: str, api_key: str) -> Dict[str, Any]:
     headers = {"Accept": "application/json", "Key": api_key}
     params: dict[str, Union[str, int]] = {

--- a/ioc_inspector_core/report_schema.json
+++ b/ioc_inspector_core/report_schema.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "type": {"type": "string"},
+    "verdict": {"type": "string"},
+    "score": {"type": "number"},
+    "summary": {"type": "string"},
+    "urls": {"type": "array", "items": {"type": "string"}},
+    "ips": {"type": "array", "items": {"type": "string"}},
+    "url_rep": {"type": "object"},
+    "ip_rep": {"type": "object"},
+    "macro": {"type": ["boolean", "null"]},
+    "embedded_files": {"type": ["integer", "null"]},
+    "js_count": {"type": ["integer", "null"]}
+  },
+  "required": ["verdict", "score"],
+  "additionalProperties": true
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,9 @@ tldextract==5.1.2       # Clean URL domain/TLD splitting
 # ── CLI / UX ─────────────────────────────────────────────────────────────
 click==8.1.7            # Command-line interface
 
+# ── Validation
+jsonschema==4.22.0      # Ensure report output matches schema
+
 # ── Optional niceties (safe to omit) ─────────────────────────────────────
 # rich==13.7.1          # Colour console output & spinners
 # tabulate==0.9.0       # Pretty ASCII tables for --verbose

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,0 +1,49 @@
+from click.testing import CliRunner
+
+import main
+
+
+def test_cli_multiple_files(monkeypatch, tmp_path):
+    calls = []
+
+    def fake_analyze(path):
+        calls.append(path)
+        return {"score": 0, "verdict": "benign"}
+
+    monkeypatch.setattr(main, "analyze", fake_analyze)
+
+    f1 = tmp_path / "a.txt"
+    f2 = tmp_path / "b.txt"
+    f1.write_text("a")
+    f2.write_text("b")
+
+    runner = CliRunner()
+    result = runner.invoke(main.cli, ["--file", str(f1), "--file", str(f2), "--quiet"])
+    assert result.exit_code == 0
+    assert calls == [f1, f2]
+
+
+def test_cli_threads(monkeypatch, tmp_path):
+    calls = []
+
+    def fake_analyze(path):
+        calls.append(path)
+        return {"score": 0, "verdict": "benign"}
+
+    monkeypatch.setattr(main, "analyze", fake_analyze)
+
+    d = tmp_path / "data"
+    d.mkdir()
+    f1 = d / "a.txt"
+    f2 = d / "b.txt"
+    f1.write_text("a")
+    f2.write_text("b")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main.cli,
+        ["--dir", str(d), "--quiet", "--threads", "2"],
+    )
+    assert result.exit_code == 0
+    assert set(calls) == {f1, f2}
+


### PR DESCRIPTION
## Summary
- add `--threads` CLI option to process files in parallel
- update README with concurrency bullet and feature table
- test threaded directory scanning via CLI

## Testing
- `ruff check .`
- `mypy ioc_inspector_core main.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688115ddee988327b4370576e75e10d3